### PR TITLE
CI: Stop running CI on Intel macOS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,6 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
-          - macos-15-intel # Intel
           - macos-14       # Apple Silicon
           - macos-15       # Apple Silicon
           - macos-26


### PR DESCRIPTION
From upstream:

> We are winding down support for Intel and will no longer be doing any mass bottling for that platform.

Source: https://github.com/orgs/Homebrew/discussions/6624#discussioncomment-15336620