### PR TITLE
CI: Omnibus PR to fix Linux CI (install bubblewrap and enable user namspaces, `brew trust` my tap, drop support for Ubuntu 22.04, keep support for Ubuntu 24.04)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,16 @@ jobs:
         with:
           token: ${{ steps.generate-token.outputs.token }}
 
+      # Homebrew's Linux sandbox requires bwrap on PATH before brew pr-pull runs brew doctor.
+      # The sysctls enable the rootless user namespaces that bwrap needs to create the sandbox.
+      - name: Set up Homebrew Linux sandbox
+        if: runner.os == 'Linux'
+        run: |
+          brew install bubblewrap
+          sudo sysctl -w kernel.unprivileged_userns_clone=1
+          sudo sysctl -w user.max_user_namespaces=28633
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
+
       - name: Set up git
         # This repo does not make tags or releases
         uses: Homebrew/actions/git-user-config@6eaeff80e7e5c43087c0e5eb5aa82120399e9c91 # main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,6 +39,9 @@ jobs:
           sudo sysctl -w user.max_user_namespaces=28633
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
 
+      # Trust my tap
+      - run: brew trust dilumaluthge/tap
+
       - name: Set up git
         # This repo does not make tags or releases
         uses: Homebrew/actions/git-user-config@6eaeff80e7e5c43087c0e5eb5aa82120399e9c91 # main

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,6 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-22.04
           - ubuntu-24.04
           - macos-14       # Apple Silicon
           - macos-15       # Apple Silicon

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,6 +38,17 @@ jobs:
           key: ${{ matrix.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
           restore-keys: ${{ matrix.os }}-rubygems-
 
+      # Homebrew's Linux sandbox requires bwrap on PATH before brew test-bot runs brew doctor.
+      # Install it after cleanup-before, which prunes formulae from the prefix.
+      # The sysctls enable the rootless user namespaces that bwrap needs to create the sandbox.
+      - name: Set up Homebrew Linux sandbox
+        if: runner.os == 'Linux'
+        run: |
+          brew install bubblewrap
+          sudo sysctl -w kernel.unprivileged_userns_clone=1
+          sudo sysctl -w user.max_user_namespaces=28633
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
+
       - run: brew test-bot --only-cleanup-before
 
       - run: brew test-bot --only-setup

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,6 +49,9 @@ jobs:
           sudo sysctl -w user.max_user_namespaces=28633
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
 
+      # Trust my tap
+      - run: brew trust dilumaluthge/tap
+
       - run: brew test-bot --only-cleanup-before
 
       - run: brew test-bot --only-setup


### PR DESCRIPTION
1. Install bubblewrap and enable user namespaces (required for Homebrew's new sandboxing on Linux). Taken from https://github.com/LizardByte/homebrew-homebrew/pull/274 (https://github.com/LizardByte/homebrew-homebrew/commit/66235ac0ae1cb7ed7fb0830f18d417004579f8d8) with the author's permission (license: MIT).
2. `brew trust` my tap.
3. Drop support for Ubuntu 22.04, keep support for Ubuntu 24.04.