### PR TITLE
Omnibus PR to fix CI (brew style fix for `formula_opt_prefix` in the formulas for `pijul` and `shyaml-rs`, update `homebrew/actions` digest, migrate to `BREW_COMMIT_CLIENT_ID`, and use a different URL for the brew `homepage` in the `pijul` formula)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Set up Homebrew
         # This repo does not make tags or releases
-        uses: Homebrew/actions/setup-homebrew@d4a9d3894e99dfb50a41c089a3dfcbd6009152a1 # main
+        uses: Homebrew/actions/setup-homebrew@c7f77f7dca7d714f9a72fde4e7b6a4e9cbf99062 # main
         with:
           token: ${{ steps.generate-token.outputs.token }}
 
@@ -44,7 +44,7 @@ jobs:
 
       - name: Set up git
         # This repo does not make tags or releases
-        uses: Homebrew/actions/git-user-config@d4a9d3894e99dfb50a41c089a3dfcbd6009152a1 # main
+        uses: Homebrew/actions/git-user-config@c7f77f7dca7d714f9a72fde4e7b6a4e9cbf99062 # main
 
       - name: Pull bottles
         env:
@@ -54,7 +54,7 @@ jobs:
 
       - name: Push commits
         # This repo does not make tags or releases
-        uses: Homebrew/actions/git-try-push@d4a9d3894e99dfb50a41c089a3dfcbd6009152a1 # main
+        uses: Homebrew/actions/git-try-push@c7f77f7dca7d714f9a72fde4e7b6a4e9cbf99062 # main
         with:
           branch: main
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.BREW_COMMIT_APP_ID }}
+          app-id: ${{ vars.BREW_COMMIT_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Set up Homebrew

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Homebrew
         id: set-up-homebrew
         # This repo does not make tags or releases
-        uses: Homebrew/actions/setup-homebrew@d4a9d3894e99dfb50a41c089a3dfcbd6009152a1 # main
+        uses: Homebrew/actions/setup-homebrew@c7f77f7dca7d714f9a72fde4e7b6a4e9cbf99062 # main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/Formula/pijul.rb
+++ b/Formula/pijul.rb
@@ -6,8 +6,9 @@
 
 class Pijul < Formula
   desc "Patch-based distributed version control system"
-  homepage "https://pijul.org"
+  # Web page: https://pijul.org
   # Crate: https://crates.io/crates/pijul
+  homepage "https://docs.rs/crate/pijul"
   url "https://static.crates.io/crates/pijul/pijul-1.0.0-beta.13.crate"
   # version is automatically extracted from the url
   sha256 "d5f8e59409b31bfa76a3b45c0e076f5852a4eb6b3134497b9a902927bdd6f9bf"

--- a/Formula/pijul.rb
+++ b/Formula/pijul.rb
@@ -12,15 +12,7 @@ class Pijul < Formula
   # version is automatically extracted from the url
   sha256 "d5f8e59409b31bfa76a3b45c0e076f5852a4eb6b3134497b9a902927bdd6f9bf"
   license "GPL-2.0"
-  # revision 1
-
-  bottle do
-    root_url "https://github.com/DilumAluthge/homebrew-tap/releases/download/pijul-1.0.0-beta.13"
-    sha256 cellar: :any, arm64_tahoe:   "ff9b2eb52af5df39a88735ab7f8803e2bb6f374252e7ea822dd6ad050fcfcd69"
-    sha256 cellar: :any, arm64_sequoia: "ad14afacae2370639fc495d9182b375a296885a65af4f033ab0a54cd80528bea"
-    sha256 cellar: :any, arm64_sonoma:  "cc8f32b807d1af2147d7f0ab578aa397fe29c0910a1845785a5081622d43ee43"
-    sha256 cellar: :any, x86_64_linux:  "0d59d52c5602931d626f7524ffceca4356cceebe94fc3c8c3c3ad67856c4f889"
-  end
+  revision 1
 
   depends_on "pkg-config" => :build
   depends_on "rust" => :build
@@ -34,7 +26,7 @@ class Pijul < Formula
   def install
     # Ensure that the `openssl` crate picks up the intended library.
     # https://docs.rs/openssl/0.10.75/openssl/#manual
-    ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
+    ENV["OPENSSL_DIR"] = formula_opt_prefix("openssl@3")
 
     # Build pijul, and install it into the Homebrew prefix:
     system "cargo", "install", "--locked", "--root", prefix, "--path", "."

--- a/Formula/shyaml-rs.rb
+++ b/Formula/shyaml-rs.rb
@@ -6,15 +6,7 @@ class ShyamlRs < Formula
   # version is automatically extracted from the url
   sha256 "46dbc216a9b92b5d82412ffa9114109f4500c8c02e4330588800d0edba264686"
   license "MIT"
-  revision 2
-
-  bottle do
-    root_url "https://github.com/DilumAluthge/homebrew-tap/releases/download/shyaml-rs-0.3.2_2"
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "1e56bba7015b0815ad28765bea429a9c64add4701589268b4d49e3404718880e"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "c4c22b16098204deae736e2debf6b3b90cf168f923bcd78bc41f9dcc8b9ecc8c"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "d29f3270cbf64227a71ae9f30f11efe2f3c6bf44d8289d7668c54fbe9310bbdd"
-    sha256 cellar: :any,                 x86_64_linux:  "496ab9e9f8dd7ed42d69c9fe075b0860bb8c23f1658f93fff4a2ac14c609da9c"
-  end
+  revision 3
 
   depends_on "rust" => :build
   depends_on "openssl@3"
@@ -24,7 +16,7 @@ class ShyamlRs < Formula
   def install
     # Ensure that the `openssl` crate picks up the desired library
     # https://docs.rs/openssl/0.10.75/openssl/#manual
-    ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
+    ENV["OPENSSL_DIR"] = formula_opt_prefix("openssl@3")
 
     # Build shyaml-rs from source, and install it into the prefix
     system "cargo", "install", "--locked", "--root", prefix, "--path", "."


### PR DESCRIPTION
1.  Brew style fix: Use `formula_opt_prefix` in the formulas for `pijul` and `shyaml-rs`
2. CI: Update `homebrew/actions` digest to `c7f77f7 `
3. CI: Migrate from `BREW_COMMIT_APP_ID` to `BREW_COMMIT_CLIENT_ID`
4. #97 <!-- Pijul: Use Pijul `docs.rs` URL as the brew `homepage` -->

TODO:
- [x] Fix revision
- [ ] Squash revision commit