### PR TITLE
Bump `shyaml-rs` from 0.3.2 to 0.3.3

### DIFF
--- a/Formula/shyaml-rs.rb
+++ b/Formula/shyaml-rs.rb
@@ -2,19 +2,11 @@ class ShyamlRs < Formula
   desc "Command-line tool for working with YAML files"
   homepage "https://github.com/0k/shyaml-rs"
   # Crate: https://crates.io/crates/shyaml-rs
-  url "https://static.crates.io/crates/shyaml-rs/shyaml-rs-0.3.2.crate"
+  url "https://static.crates.io/crates/shyaml-rs/shyaml-rs-0.3.3.crate"
   # version is automatically extracted from the url
-  sha256 "46dbc216a9b92b5d82412ffa9114109f4500c8c02e4330588800d0edba264686"
+  sha256 "bfc4e887290afb007b52533e0634c35dd239a430e52924f94158eea90f522633"
   license "MIT"
-  revision 3
-
-  bottle do
-    root_url "https://github.com/DilumAluthge/homebrew-tap/releases/download/shyaml-rs-0.3.2_3"
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "8c4fe8256f938e0e065f306ea2d28997ba5a35ba19635b538d8bd219e74e81cf"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "b8c542685def9b379a7c7a1f234872b092625a5798415210f6cbd5865401ac87"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "adeba9afca3b57784ebad09752797faee924cd70ade12e4366ac9e0b3dbfcd0c"
-    sha256 cellar: :any,                 x86_64_linux:  "07d5b1c03266e8ac46edd71d3660f7e4b288db49c80c61ad1feae3a6e311c41e"
-  end
+  # revision 0
 
   depends_on "rust" => :build
   depends_on "openssl@3"


### PR DESCRIPTION
Git release: https://github.com/0k/shyaml-rs/releases/tag/0.3.3
Crate release: https://crates.io/crates/shyaml-rs/0.3.3