### PR TITLE
`pijul`: Upgrade from `1.0.0-beta.15` to `1.0.0-beta.17`

### DIFF
--- a/Formula/pijul.rb
+++ b/Formula/pijul.rb
@@ -9,9 +9,9 @@ class Pijul < Formula
   # Web page: https://pijul.org
   # Crate: https://crates.io/crates/pijul
   homepage "https://docs.rs/crate/pijul"
-  url "https://static.crates.io/crates/pijul/pijul-1.0.0-beta.15.crate"
+  url "https://static.crates.io/crates/pijul/pijul-1.0.0-beta.17.crate"
   # version is automatically extracted from the url
-  sha256 "67f7aa09d89b58698b30d3f71ed6edbdc2450dcc80c485aa484d5c02143ac326"
+  sha256 "81e9a6685477a853d0025b0ecc174848b449b7f5f527c1520ce0a1da76732b73"
   license "GPL-2.0"
   # revision 0
 


### PR DESCRIPTION
1.0.0-beta.15: https://crates.io/crates/pijul/1.0.0-beta.15
1.0.0-beta.17: https://crates.io/crates/pijul/1.0.0-beta.17

AFAICT, `1.0.0-beta.16` does not exist.