### PR TITLE
`shyaml-rs`: Remove `depends_on :macos` from the `shyaml-rs` formula code

### DIFF
--- a/Formula/shyaml-rs.rb
+++ b/Formula/shyaml-rs.rb
@@ -16,12 +16,6 @@ class ShyamlRs < Formula
   end
 
   depends_on "rust" => :build
-
-  # For now, mark this formula as macOS-only
-  # (because the Linux build is currently broken - 0.3.2 was fine, but 0.3.3 is broken)
-  # TODO: Start building Linux bottles again, once the Linux build has been fixed upstream
-  depends_on :macos
-
   depends_on "openssl@3"
 
   conflicts_with "shyaml", because: "both install `shyaml` binaries"

--- a/Formula/shyaml-rs.rb
+++ b/Formula/shyaml-rs.rb
@@ -6,7 +6,7 @@ class ShyamlRs < Formula
   # version is automatically extracted from the url
   sha256 "debc2be8ac7da2cc6cf749ad1231ea151476b635ef55e93eafea3acbb2892dc8"
   license "MIT"
-  # revision 0
+  revision 1
 
   bottle do
     root_url "https://github.com/DilumAluthge-packaging/homebrew-tap/releases/download/shyaml-rs-0.3.4"


### PR DESCRIPTION
This won't magically un-break the build, but it will allow us to at least get CI logs that show the build failure.