### PR TITLE
Renovate config: Remove a trailing comma

### DIFF
--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -6,7 +6,7 @@
     ":separateMultipleMajorReleases",
     ":separateMultipleMinorReleases",
     ":separatePatchReleases",
-    ":enableVulnerabilityAlerts",
+    ":enableVulnerabilityAlerts"
   ],
   "rebaseWhen": "conflicted",
 


### PR DESCRIPTION
Because JSON doesn't allow trailing commas.